### PR TITLE
Add email to team schema

### DIFF
--- a/schemas/team.js
+++ b/schemas/team.js
@@ -54,6 +54,12 @@ export default {
       title: 'Twitter',
       type: 'string',
       fieldset: 'social'
+    },
+    {
+      name: 'email',
+      title: 'Email',
+      type: 'string',
+      fieldset: 'social'
     }
   ],
   orderings: [


### PR DESCRIPTION
Adding email to Sanity team schema for Trello Card:  https://trello.com/c/jjEeir6V/107-add-social-media-icons-mail-button-under-each-persons-face